### PR TITLE
Avoid duplicate VM names

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -4,7 +4,6 @@ Classe com funções básicas de teste
 from vmm_manager.entidade.inventario import Inventario
 from vmm_manager.entidade.vm import VM
 from vmm_manager.entidade.vm_rede import VMRede
-from vmm_manager.parser.parser_local import ParserLocal
 
 
 class Base():
@@ -27,7 +26,7 @@ class Base():
                 maquina_virtual.get('descricao'),
                 maquina_virtual.get(
                     'imagem', array_yaml[0][0].get('imagem_padrao', None)),
-                maquina_virtual.get('regiao', ParserLocal.REGIAO_PADRAO),
+                maquina_virtual.get('regiao', Inventario.REGIAO_PADRAO),
                 maquina_virtual.get(
                     'qtde_cpu', array_yaml[0][0].get('qtde_cpu_padrao', None)),
                 maquina_virtual.get(

--- a/vmm_manager/entidade/acao.py
+++ b/vmm_manager/entidade/acao.py
@@ -40,7 +40,7 @@ class Acao(YamlAble):
             return cmd
 
         raise AttributeError(
-            'Ação "{}" não possui comando de pós execução.'.format(self.nome_comando))
+            'Ação "{}" não possui comando de pós-execução.'.format(self.nome_comando))
 
     def get_str_impressao_inline(self):
         return '{} - [{}]'.format(self.nome_comando,

--- a/vmm_manager/entidade/acao.py
+++ b/vmm_manager/entidade/acao.py
@@ -1,6 +1,7 @@
 """
 Representação de uma ação (um item do plano de execução)
 """
+import json
 from yamlable import yaml_info, YamlAble
 from vmm_manager.infra.comando import Comando
 from vmm_manager.util.config import CAMPO_AGRUPAMENTO, CAMPO_ID, CAMPO_IMAGEM, CAMPO_REGIAO
@@ -12,18 +13,42 @@ class Acao(YamlAble):
         self.nome_comando = nome_comando
         self.args = kwargs
 
+        self.__status_execucao = None
+        self.__retorno_execucao = None
+
     def executar(self, agrupamento, nuvem, servidor_acesso, guid):
         cmd = Comando(self.nome_comando,
                       agrupamento=agrupamento,
+                      campo_agrupamento=CAMPO_AGRUPAMENTO[0],
                       nuvem=nuvem,
                       guid=guid,
                       servidor_vmm=servidor_acesso.servidor_vmm)
         cmd.args.update(self.args)
 
-        return cmd.executar(servidor_acesso)
+        status, retorno = cmd.executar(servidor_acesso)
+
+        self.__status_execucao = status
+        self.__retorno_execucao = json.loads(
+            retorno) if self.__status_execucao else retorno
+
+        return self.__status_execucao, self.__retorno_execucao
 
     def is_criacao_vm(self):
         return self.nome_comando == 'criar_vm'
+
+    def has_cmd_pos_execucao(self):
+        return self.is_criacao_vm()
+
+    def was_executada_com_sucesso(self):
+        return (self.__status_execucao and
+                self.__retorno_execucao.get('Status') == 'OK')
+
+    def get_resultado_execucao(self):
+        if self.__status_execucao is None:
+            raise AttributeError('Ação não executada.')
+        if self.__status_execucao:
+            return self.__retorno_execucao
+        return {'Msgs': self.__retorno_execucao}
 
     def get_cmd_pos_execucao(self, agrupamento, servidor_acesso):
         if self.is_criacao_vm():

--- a/vmm_manager/entidade/plano_execucao.py
+++ b/vmm_manager/entidade/plano_execucao.py
@@ -2,6 +2,7 @@
 Representação de um plano de execução
 """
 import os
+import json
 import uuid
 import textwrap
 from yamlable import yaml_info, YamlAble
@@ -81,17 +82,20 @@ class PlanoExecucao(YamlAble):
                     self.agrupamento, self.nuvem, servidor_acesso, guid)
 
                 # Tratando resultado
-                if status:
-                    if retorno:
+                resultado = json.loads(retorno)
+                if status and resultado.get('Status') == 'OK':
+                    guid = resultado.get('Guid')
+                    if guid:
                         # Job em execução
-                        self.__jobs_em_execucao[retorno] = SCJob(retorno, acao)
-                        print('[Iniciado {}]'.format(retorno))
+                        self.__jobs_em_execucao[guid] = SCJob(
+                            guid, acao)
+                        print('[Iniciado {}]'.format(guid))
                     else:
                         # Comando já finalizado
                         imprimir_ok(ocultar_progresso)
                 else:
                     imprimir_erro(ocultar_progresso)
-                    self.__logar_erros_acao(acao, retorno)
+                    self.__logar_erros_acao(acao, resultado.get('Msgs'))
 
             # Monitorando jobs
             SCJob.monitorar_jobs(self.__jobs_em_execucao, servidor_acesso)

--- a/vmm_manager/entidade/plano_execucao.py
+++ b/vmm_manager/entidade/plano_execucao.py
@@ -2,7 +2,6 @@
 Representação de um plano de execução
 """
 import os
-import json
 import uuid
 import textwrap
 from yamlable import yaml_info, YamlAble

--- a/vmm_manager/includes/ps_templates/criar_vm.j2
+++ b/vmm_manager/includes/ps_templates/criar_vm.j2
@@ -7,30 +7,47 @@ $CPUCount = "{{ qtde_cpu }}"
 $MemoryMB = "{{ qtde_ram_mb }}"
 $CloudName = "{{ nuvem }}"
 
-# Variáveis de controle
-$JobGroupID = "{{ guid }}"
-$TemporaryName = "$JobGroupID"
-$Template = Get-SCVMTemplate -VMMServer $VMMServer -Name $TemplateName
-$CPUType = $Template.CPUType
-$CapabilityProfile = $Template.CapabilityProfile
-$OperatingSystem = $Template.OperatingSystem
-$MemoryMBMin = [math]::min( 512 , $MemoryMB )
+# Validações
+$MsgsErro = 'Teste\r\nTeste2'
+
+if ($MsgsErro){
+  $Resultado = [PSCustomObject]@{
+    Status = 'ERRO'
+    Msgs = $MsgsErro
+  }
+
+}else{
+
+  # Variáveis de controle
+  $JobGroupID = "{{ guid }}"
+  $TemporaryName = "$JobGroupID"
+  $Template = Get-SCVMTemplate -VMMServer $VMMServer -Name $TemplateName
+  $CPUType = $Template.CPUType
+  $CapabilityProfile = $Template.CapabilityProfile
+  $OperatingSystem = $Template.OperatingSystem
+  $MemoryMBMin = [math]::min( 512 , $MemoryMB )
 
 
-New-SCVirtualScsiAdapter -VMMServer $VMMServer  -JobGroup $JobGroupID -AdapterID 7 -ShareVirtualScsiAdapter $false -ScsiControllerType DefaultTypeNoType
-New-SCVirtualDVDDrive -VMMServer $VMMServer -JobGroup $JobGroupID -Bus 0 -LUN 1
+  New-SCVirtualScsiAdapter -VMMServer $VMMServer  -JobGroup $JobGroupID -AdapterID 7 -ShareVirtualScsiAdapter $false -ScsiControllerType DefaultTypeNoType
+  New-SCVirtualDVDDrive -VMMServer $VMMServer -JobGroup $JobGroupID -Bus 0 -LUN 1
 
-{% for rede in redes %}
-$VMNetwork{{ loop.index }} = Get-SCVMNetwork -VMMServer $VMMServer -Name "{{ rede }}"
-New-SCVirtualNetworkAdapter -VMMServer $VMMServer -JobGroup $JobGroupID  -VMNetwork $VMNetwork{{ loop.index }} -MACAddress "00:00:00:00:00:00" -MACAddressType Static -Synthetic -EnableVMNetworkOptimization $false -EnableMACAddressSpoofing $false -EnableGuestIPNetworkVirtualizationUpdates $false -IPv4AddressType Static -IPv6AddressType Dynamic -DevicePropertiesAdapterNameMode Disabled 
-{% endfor %}
+  {% for rede in redes %}
+  $VMNetwork{{ loop.index }} = Get-SCVMNetwork -VMMServer $VMMServer -Name "{{ rede }}"
+  New-SCVirtualNetworkAdapter -VMMServer $VMMServer -JobGroup $JobGroupID  -VMNetwork $VMNetwork{{ loop.index }} -MACAddress "00:00:00:00:00:00" -MACAddressType Static -Synthetic -EnableVMNetworkOptimization $false -EnableMACAddressSpoofing $false -EnableGuestIPNetworkVirtualizationUpdates $false -IPv4AddressType Static -IPv6AddressType Dynamic -DevicePropertiesAdapterNameMode Disabled 
+  {% endfor %}
 
-$HardwareProfile = New-SCHardwareProfile -VMMServer $VMMServer -JobGroup $JobGroupID -Name $TemporaryName -CPUType $CPUType -CapabilityProfile $CapabilityProfile -Description "Perfil temporário do vmm_manager" -CPUCount $CPUCount -MemoryMB $MemoryMB -DynamicMemoryEnabled $true -DynamicMemoryMinimumMB $MemoryMBMin -DynamicMemoryMaximumMB $MemoryMB -DynamicMemoryBufferPercentage 20 -MemoryWeight 5000 -CPUExpectedUtilizationPercent 20 -DiskIops 0 -CPUMaximumPercent 100 -CPUReserve 0 -NumaIsolationRequired $false -NetworkUtilizationMbps 0 -CPURelativeWeight 100 -HighlyAvailable $true -HAVMPriority 2000 -DRProtectionRequired $false -SecureBootEnabled $false -CPULimitFunctionality $false -CPULimitForMigration $false -CheckpointType Production -Generation 2
-$Template = New-SCVMTemplate -JobGroup $JobGroupID -Name $TemporaryName  -ComputerName $VMName -Template $Template -HardwareProfile $HardwareProfile -OperatingSystem $OperatingSystem -UpdateManagementProfile $null -LocalAdministratorCredential $null
+  $HardwareProfile = New-SCHardwareProfile -VMMServer $VMMServer -JobGroup $JobGroupID -Name $TemporaryName -CPUType $CPUType -CapabilityProfile $CapabilityProfile -Description "Perfil temporário do vmm_manager" -CPUCount $CPUCount -MemoryMB $MemoryMB -DynamicMemoryEnabled $true -DynamicMemoryMinimumMB $MemoryMBMin -DynamicMemoryMaximumMB $MemoryMB -DynamicMemoryBufferPercentage 20 -MemoryWeight 5000 -CPUExpectedUtilizationPercent 20 -DiskIops 0 -CPUMaximumPercent 100 -CPUReserve 0 -NumaIsolationRequired $false -NetworkUtilizationMbps 0 -CPURelativeWeight 100 -HighlyAvailable $true -HAVMPriority 2000 -DRProtectionRequired $false -SecureBootEnabled $false -CPULimitFunctionality $false -CPULimitForMigration $false -CheckpointType Production -Generation 2
+  $Template = New-SCVMTemplate -JobGroup $JobGroupID -Name $TemporaryName  -ComputerName $VMName -Template $Template -HardwareProfile $HardwareProfile -OperatingSystem $OperatingSystem -UpdateManagementProfile $null -LocalAdministratorCredential $null
 
-$virtualMachineConfiguration = New-SCVMConfiguration -VMTemplate $Template -Name $VMName
-$cloud = Get-SCCloud -Name $CloudName
-New-SCVirtualMachine -Name $VMName -VMConfiguration $virtualMachineConfiguration -Cloud $cloud -Description $Description -JobVariable "VMMJob" -JobGroup $JobGroupID -ReturnImmediately -StartAction "TurnOnVMIfRunningWhenVSStopped" -StopAction "SaveVM" -StartVM
+  $virtualMachineConfiguration = New-SCVMConfiguration -VMTemplate $Template -Name $VMName
+  $cloud = Get-SCCloud -Name $CloudName
+  New-SCVirtualMachine -Name $VMName -VMConfiguration $virtualMachineConfiguration -Cloud $cloud -Description $Description -JobVariable "VMMJob" -JobGroup $JobGroupID -ReturnImmediately -StartAction "TurnOnVMIfRunningWhenVSStopped" -StopAction "SaveVM" -StartVM
 
+  $Resultado = [PSCustomObject]@{
+    Status = 'OK'
+    Guid = $VMMJob.ID.Guid
+  }
 
-Write-Host -NoNewline $VMMJob.ID.Guid
+}
+
+ConvertTo-Json -Depth 3 $Resultado

--- a/vmm_manager/includes/ps_templates/criar_vm.j2
+++ b/vmm_manager/includes/ps_templates/criar_vm.j2
@@ -8,16 +8,44 @@ $MemoryMB = "{{ qtde_ram_mb }}"
 $CloudName = "{{ nuvem }}"
 
 # Validações
-$MsgsErro = 'Teste\r\nTeste2'
+$MsgsErro = ''
 
+$nuvem = Get-SCCloud -VMMServer $VMMServer -Name $CloudName
+if (!$nuvem ) {
+  $MsgsErro += "Nuvem (Cloud) $CloudName não encontrada.`n"
+}
+
+$imagem = Get-SCVMTemplate -VMMServer $VMMServer | Where {$_.Name -eq $TemplateName }
+if (!$imagem ) {
+  $MsgsErro += "Imagem (Template) $TemplateName não encontrada.`n"
+}
+
+{% for rede in redes %}
+$rede = Get-SCVMNetwork -VMMServer $VMMServer -Name "{{ rede }}"
+if (!$rede ) {
+  $MsgsErro += "Rede {{ rede }} não encontrada.`n"
+}
+{% endfor %}
+
+if ($nuvem){
+  $custom_agrupamento = Get-SCCustomProperty -VMMServer $VMMServer -Name "{{ campo_agrupamento }}"
+  $vms_nuvem = Get-SCVirtualMachine -VMMServer $VMMServer -Cloud $nuvem
+  foreach($vm in $vms_nuvem) {
+    $agrupamento = Get-SCCustomPropertyValue -InputObject $vm -CustomProperty $custom_agrupamento
+    if ($agrupamento.Value -ne "{{ agrupamento }}" -and $vm.Name -eq $VMName) {
+      $MsgsErro += "O nome '$vm' já está sendo usado por uma VM na nuvem '$nuvem'.`n"
+    }
+  }
+}
+
+
+# Tratando erro
 if ($MsgsErro){
   $Resultado = [PSCustomObject]@{
     Status = 'ERRO'
     Msgs = $MsgsErro
   }
-
 }else{
-
   # Variáveis de controle
   $JobGroupID = "{{ guid }}"
   $TemporaryName = "$JobGroupID"
@@ -28,16 +56,16 @@ if ($MsgsErro){
   $MemoryMBMin = [math]::min( 512 , $MemoryMB )
 
 
-  New-SCVirtualScsiAdapter -VMMServer $VMMServer  -JobGroup $JobGroupID -AdapterID 7 -ShareVirtualScsiAdapter $false -ScsiControllerType DefaultTypeNoType
+  New-SCVirtualScsiAdapter -VMMServer $VMMServer -JobGroup $JobGroupID -AdapterID 7 -ShareVirtualScsiAdapter $false -ScsiControllerType DefaultTypeNoType
   New-SCVirtualDVDDrive -VMMServer $VMMServer -JobGroup $JobGroupID -Bus 0 -LUN 1
 
   {% for rede in redes %}
   $VMNetwork{{ loop.index }} = Get-SCVMNetwork -VMMServer $VMMServer -Name "{{ rede }}"
-  New-SCVirtualNetworkAdapter -VMMServer $VMMServer -JobGroup $JobGroupID  -VMNetwork $VMNetwork{{ loop.index }} -MACAddress "00:00:00:00:00:00" -MACAddressType Static -Synthetic -EnableVMNetworkOptimization $false -EnableMACAddressSpoofing $false -EnableGuestIPNetworkVirtualizationUpdates $false -IPv4AddressType Static -IPv6AddressType Dynamic -DevicePropertiesAdapterNameMode Disabled 
+  New-SCVirtualNetworkAdapter -VMMServer $VMMServer -JobGroup $JobGroupID -VMNetwork $VMNetwork{{ loop.index }} -MACAddress "00:00:00:00:00:00" -MACAddressType Static -Synthetic -EnableVMNetworkOptimization $false -EnableMACAddressSpoofing $false -EnableGuestIPNetworkVirtualizationUpdates $false -IPv4AddressType Static -IPv6AddressType Dynamic -DevicePropertiesAdapterNameMode Disabled 
   {% endfor %}
 
   $HardwareProfile = New-SCHardwareProfile -VMMServer $VMMServer -JobGroup $JobGroupID -Name $TemporaryName -CPUType $CPUType -CapabilityProfile $CapabilityProfile -Description "Perfil temporário do vmm_manager" -CPUCount $CPUCount -MemoryMB $MemoryMB -DynamicMemoryEnabled $true -DynamicMemoryMinimumMB $MemoryMBMin -DynamicMemoryMaximumMB $MemoryMB -DynamicMemoryBufferPercentage 20 -MemoryWeight 5000 -CPUExpectedUtilizationPercent 20 -DiskIops 0 -CPUMaximumPercent 100 -CPUReserve 0 -NumaIsolationRequired $false -NetworkUtilizationMbps 0 -CPURelativeWeight 100 -HighlyAvailable $true -HAVMPriority 2000 -DRProtectionRequired $false -SecureBootEnabled $false -CPULimitFunctionality $false -CPULimitForMigration $false -CheckpointType Production -Generation 2
-  $Template = New-SCVMTemplate -JobGroup $JobGroupID -Name $TemporaryName  -ComputerName $VMName -Template $Template -HardwareProfile $HardwareProfile -OperatingSystem $OperatingSystem -UpdateManagementProfile $null -LocalAdministratorCredential $null
+  $Template = New-SCVMTemplate -JobGroup $JobGroupID -Name $TemporaryName -ComputerName $VMName -Template $Template -HardwareProfile $HardwareProfile -OperatingSystem $OperatingSystem -UpdateManagementProfile $null -LocalAdministratorCredential $null
 
   $virtualMachineConfiguration = New-SCVMConfiguration -VMTemplate $Template -Name $VMName
   $cloud = Get-SCCloud -Name $CloudName
@@ -47,7 +75,6 @@ if ($MsgsErro){
     Status = 'OK'
     Guid = $VMMJob.ID.Guid
   }
-
 }
 
 ConvertTo-Json -Depth 3 $Resultado

--- a/vmm_manager/includes/ps_templates/excluir_vm.j2
+++ b/vmm_manager/includes/ps_templates/excluir_vm.j2
@@ -1,6 +1,13 @@
 $vm = Get-SCVirtualMachine -VMMServer "{{ servidor_vmm }}" -ID "{{ id_vmm }}"
+
 if ($vm.Status -eq 'Running' ){
     Stop-SCVirtualMachine -Force -VM $vm | Out-Null
 }
+
 Remove-SCVirtualMachine -VM $vm -JobVariable "job" -RunAsynchronously | Out-Null
-Write-Host -NoNewline $job.ID
+
+$Resultado = [PSCustomObject]@{
+    Status = 'OK'
+    Guid = $job.ID
+}
+ConvertTo-Json -Depth 3 $Resultado

--- a/vmm_manager/includes/ps_templates/validar_inventario.j2
+++ b/vmm_manager/includes/ps_templates/validar_inventario.j2
@@ -22,3 +22,13 @@ if (!$rede ) {
   Write-Host "Rede '{{ rede }}' não encontrada."
 }
 {% endfor %} 
+
+$custom_agrupamento = Get-SCCustomProperty -VMMServer "{{ servidor_vmm }}" -Name "{{ campo_agrupamento }}"
+$vms_nuvem = Get-SCVirtualMachine -VMMServer "{{ servidor_vmm }}" -Cloud $nuvem
+$nomes_vm_desejados = @({{ lista_nome_vms_str }})
+foreach($vm in $vms_nuvem) {
+  $agrupamento = Get-SCCustomPropertyValue -InputObject $vm -CustomProperty $custom_agrupamento
+  if ($agrupamento.Value -ne "{{ agrupamento }}" -and $nomes_vm_desejados -Contains $vm.Name) {
+    Write-Output "O nome '$vm' já está sendo usado por uma VM na nuvem '$nuvem'. Por favor, escolha outro nome."
+  }
+}

--- a/vmm_manager/parser/parser_local.py
+++ b/vmm_manager/parser/parser_local.py
@@ -3,14 +3,12 @@ Módulo que realiza o parser de um inventário local
 """
 import os
 import yamale
-from vmm_manager.infra.comando import Comando
 from vmm_manager.entidade.inventario import Inventario
 from vmm_manager.entidade.vm import VM
 from vmm_manager.entidade.vm_rede import VMRede
 
 
 class ParserLocal:
-    REGIAO_PADRAO = 'default'
     __ARQUIVO_SCHEMA = '../includes/schema.yaml'
     __YAML_PARSER = 'ruamel'
 
@@ -30,43 +28,6 @@ class ParserLocal:
             raise ValueError('Arquivo de inventário não encontrado.')
         if os.stat(self.__arquivo_inventario).st_size == 0:
             raise ValueError('Arquivo de inventário vazio.')
-
-    def __validar_inventario_servidor(self, servidor_acesso):
-        imagens = set()
-        redes = set()
-        regioes = set()
-
-        for maquina_virtual in self.__inventario.vms.values():
-            if maquina_virtual.imagem is None:
-                raise ValueError(
-                    'Imagem da VM {} não definida.'.format(maquina_virtual.nome))
-            imagens.add(maquina_virtual.imagem)
-
-            if maquina_virtual.regiao != ParserLocal.REGIAO_PADRAO:
-                regioes.add(maquina_virtual.regiao)
-
-            if maquina_virtual.qtde_cpu is None:
-                raise ValueError(
-                    'Quantidade de CPUs da VM {} não definida.'.format(maquina_virtual.nome))
-
-            if maquina_virtual.qtde_ram_mb is None:
-                raise ValueError(
-                    'Quantidade de memória da VM {} não definida.'.format(maquina_virtual.nome))
-
-            if maquina_virtual.get_qtde_rede_principal() != 1:
-                raise ValueError(
-                    'VM {} deve ter exatamente uma rede principal.'.format(maquina_virtual.nome))
-
-            redes.update([rede.nome for rede in maquina_virtual.redes])
-
-        cmd = Comando('validar_inventario', imagens=imagens,
-                      nuvem=self.__inventario.nuvem,
-                      redes=redes,
-                      servidor_vmm=servidor_acesso.servidor_vmm,
-                      qtde_minima_regioes=len(regioes))
-        _, msg = cmd.executar(servidor_acesso)
-        if msg:
-            raise ValueError(msg)
 
     def __montar_inventario(self, dados_inventario):
         nomes_vm = []
@@ -90,7 +51,7 @@ class ParserLocal:
                 maquina_virtual.get('descricao'),
                 maquina_virtual.get(
                     'imagem', dados_inventario.get('imagem_padrao', None)),
-                maquina_virtual.get('regiao', ParserLocal.REGIAO_PADRAO),
+                maquina_virtual.get('regiao', Inventario.REGIAO_PADRAO),
                 maquina_virtual.get(
                     'qtde_cpu', dados_inventario.get('qtde_cpu_padrao', None)),
                 maquina_virtual.get(
@@ -110,7 +71,7 @@ class ParserLocal:
                 dados_inventario = yamale.validate(ParserLocal.__get_schema_yaml(),
                                                    dados_yaml, strict=True)
                 self.__montar_inventario(dados_inventario[0][0])
-                self.__validar_inventario_servidor(servidor_acesso)
+                self.__inventario.validar_no_servidor(servidor_acesso)
             except (SyntaxError, ValueError) as ex:
                 return False, str(ex)
 

--- a/vmm_manager/vmm_manager.py
+++ b/vmm_manager/vmm_manager.py
@@ -325,7 +325,7 @@ def remover_agrupamento_da_nuvem(servidor_acesso, agrupamento, nuvem,
                 servidor_acesso, agrupamento, nuvem)
 
         plano_execucao = inventario_remoto.gerar_plano_exclusao()
-        plano_execucao.executar(servidor_acesso)
+        plano_execucao.executar(servidor_acesso, ocultar_progresso)
 
         liberar_lock(servidor_acesso, agrupamento, nuvem, ocultar_progresso)
         plano_execucao.imprimir_resultado_execucao()


### PR DESCRIPTION
O VMM permite criar vms com o mesmo nome. Porém, isso gera um bug na criação de uma VM com nome duplicado, na hora do tagueamento.

Em alguns casos, era possível, acidentalmente, alterar o agrupamento da VM.

Esse PR elimina essa possibilidade e adiciona uma validação a mais ao criar VM's.
